### PR TITLE
Fixes placeholder image

### DIFF
--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -35,12 +35,20 @@ const ItemPreview = (props) => {
       style={{ borderRadius: "20px" }}
       id={`item_${item.slug}`}
     >
+      {item.image !== "" ?
       <img
         alt="item"
         src={item.image}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
-      />
+      /> :
+      <img
+        alt="item"
+        src="/placeholder.png"
+        className="card-img-top item-img"
+        style={{ borderRadius: "20px" }}
+      /> 
+  }
       <div className="card-body">
         <Link to={`/item/${item.slug}`} className="text-white">
           <h3 className="card-title">{item.title}</h3>


### PR DESCRIPTION
# Description

The issue is found out to be seen when user do not provide image URL for a new item. In this case, ideally we suppose to show placeholder image. The fix is proposed via this PR:

## Screenshot

<img width="1280" alt="Screenshot 2023-02-08 at 21 00 28" src="https://user-images.githubusercontent.com/17321286/217638414-d903d279-46be-4ad5-adb0-6631485f4737.png">
 
